### PR TITLE
fix: `signAndSendTransaction(s)` response type change in Sender wallet

### DIFF
--- a/packages/modal-ui/package.json
+++ b/packages/modal-ui/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "@near-wallet-selector/modal-ui",
+  "name": "@corndao/wallet-selector-modal-ui",
    "version": "5.0.3"
 }

--- a/packages/sender/README.md
+++ b/packages/sender/README.md
@@ -1,4 +1,4 @@
-# @near-wallet-selector/sender
+# @corndao/wallet-selector-sender
 
 This is the [Sender](https://chrome.google.com/webstore/detail/sender-wallet/epapihdplajcdnnkdeiahlgigofloibg) package for NEAR Wallet Selector.
 
@@ -8,17 +8,17 @@ The easiest way to use this package is to install it from the NPM registry:
 
 ```bash
 # Using Yarn
-yarn add @near-wallet-selector/sender
+yarn add @corndao/wallet-selector-sender
 
 # Using NPM.
-npm install @near-wallet-selector/sender
+npm install @corndao/wallet-selector-sender
 ```
 
 Then use it in your dApp:
 
 ```ts
 import { setupWalletSelector } from "@near-wallet-selector/core";
-import { setupSender } from "@near-wallet-selector/sender";
+import { setupSender } from "@corndao/wallet-selector-sender";
 
 // Sender for Wallet Selector can be setup without any params or it can take one optional param.
 const sender = setupSender({
@@ -40,8 +40,8 @@ const selector = await setupWalletSelector({
 Assets such as icons can be found in the `/assets` directory of the package. Below is an example using Webpack:
 
 ```ts
-import { setupSender } from "@near-wallet-selector/sender";
-import senderIconUrl from "@near-wallet-selector/sender/assets/sender-icon.png";
+import { setupSender } from "@corndao/wallet-selector-sender";
+import senderIconUrl from "@corndao/wallet-selector-sender/assets/sender-icon.png";
 
 const sender = setupSender({
   iconUrl: senderIconUrl

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "@near-wallet-selector/sender",
+  "name": "@corndao/wallet-selector-sender",
    "version": "5.0.3"
 }

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -74,13 +74,22 @@ export interface SignAndSendTransactionParams {
   actions: Array<Action>;
 }
 
+export interface FunctionCallError {
+  error: {
+    index: number;
+    kind: object;
+    message: string;
+    transaction_outcome: object;
+    type: "FunctionCallError";
+  };
+}
+
 // Seems to reuse signAndSendTransactions internally, hence the wrong method name and list of responses.
 export interface SignAndSendTransactionResponse {
   actionType: "DAPP/DAPP_POPUP_RESPONSE";
   method: "signAndSendTransactions";
   notificationId: number;
-  error?: string;
-  response?: Array<providers.FinalExecutionOutcome>;
+  response: Array<providers.FinalExecutionOutcome> | FunctionCallError;
   type: "sender-wallet-extensionResult";
 }
 
@@ -88,8 +97,7 @@ export interface SignAndSendTransactionsResponse {
   actionType: "DAPP/DAPP_POPUP_RESPONSE";
   method: "signAndSendTransactions";
   notificationId: number;
-  error?: string;
-  response?: Array<providers.FinalExecutionOutcome>;
+  response: Array<providers.FinalExecutionOutcome> | FunctionCallError;
   type: "sender-wallet-extensionResult";
 }
 

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -188,8 +188,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
           actions: transformActions(actions),
         })
         .then((res) => {
-          if (res.error) {
-            throw new Error(res.error);
+          if ("error" in res.response) {
+            throw new Error(res.response.error.message);
           }
 
           // Shouldn't happen but avoids inconsistent responses.
@@ -213,8 +213,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
           transactions: transformTransactions(transactions),
         })
         .then((res) => {
-          if (res.error) {
-            throw new Error(res.error);
+          if ("error" in res.response) {
+            throw new Error(res.response.error.message);
           }
 
           // Shouldn't happen but avoids inconsistent responses.


### PR DESCRIPTION
# Description

The PR is to fix the incompatible `signAndSendTransaction` response type with Sender v1.0.0 and later version. 


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [x] BREAKING CHANGE - SPECIFY: The change will work for Sender versions after v1.0.0, but is not compatible with versions before 1.0.0.
- [ ] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
